### PR TITLE
Ignore CONFIG.MINE when building the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Programs/Public-Input
 Programs/Schedules
 compiled-programs
 Dockerfile
+CONFIG.mine


### PR DESCRIPTION
It's important to note that CONFIG.MINE is not versioned and may
therefore differ from one user to another even though they may have
checked out the exact same branch, tag, or commit. Ignoring it when
building the image can therefore help reproducing builds.

The CONFIG.MINE file is mounted when using docker-compose to run a
container and developers can still use it according to their own needs.