### PR TITLE
Do not erase mpspdz.egg-info/ dir in volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     volumes:
       - ./compiled-programs/Bytecode:/usr/src/MP-SPDZ/Programs/Bytecode
       - ./compiled-programs/Schedules:/usr/src/MP-SPDZ/Programs/Schedules
-      - ./Compiler:/usr/src/MP-SPDZ/Compiler
+      - ./Compiler/mpspdz:/usr/src/MP-SPDZ/Compiler/mpspdz
+      - ./Compiler/setup.py:/usr/src/MP-SPDZ/Compiler/setup.py
       - ./CONFIG:/usr/src/MP-SPDZ/CONFIG
       - ./Makefile:/usr/src/MP-SPDZ/Makefile
       - ./Programs/Source:/usr/src/MP-SPDZ/Programs/Source


### PR DESCRIPTION
When mounting volumes, if entire Compiler/ dir is mounted then the
`mpspdz-compile` console script will not work, when it has been
installed in develop/editable mode (e.g.: via `pip install --editable`).