### PR TITLE
Use complete tag name for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8 as base
+FROM python:3.8.13-bullseye as base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
                 automake \


### PR DESCRIPTION
This is to prevent cases where an older base image exist on the host
machine building the image, and the build fails because the expected
newer image is not being used.